### PR TITLE
fix: upstream docker tag is 0.10.0, not v0.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cfplatformeng/csb:v0.10.0 as upstream
+FROM cfplatformeng/csb:0.10.0 as upstream
 
 FROM alpine/k8s:1.20.7
 


### PR DESCRIPTION
Fix for 
![image](https://user-images.githubusercontent.com/85196563/162791586-6f6c3c9a-fa6d-49e3-ae1b-a86b702bd7bb.png)

Verified upstream, https://hub.docker.com/r/cfplatformeng/csb/tags
![image](https://user-images.githubusercontent.com/85196563/162791655-c8c0d610-0723-4160-ac64-8b04484c68f4.png)
