### PR TITLE
Use latest cloud-service-broker from Github release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,24 @@
-FROM cfplatformeng/csb:2.0.3 as upstream
+FROM alpine/k8s:1.20.7 AS upstream
+
+RUN apk update && apk upgrade && apk add --update wget
+
+RUN wget --no-verbose \
+    https://github.com/cloudfoundry/cloud-service-broker/releases/download/v2.5.6/cloud-service-broker.linux \
+    -O /bin/cloud-service-broker
 
 FROM alpine/k8s:1.20.7
 
 COPY --from=upstream /bin/cloud-service-broker /bin/cloud-service-broker
 
-RUN apk update
-RUN apk upgrade
 # Install git so we can use it to grab Terraform modules
-RUN apk add --update git zip
+RUN apk update && apk upgrade && apk add --update git zip
+
 
 # Enable re-templates of Terraform Code
 # Reference: https://github.com/GSA/data.gov/issues/3083
-ENV BROKERPAK_UPDATES_ENABLED true
+ENV BROKERPAK_UPDATES_ENABLED=true
 
-ENV PORT 8080
+ENV PORT=8080
 EXPOSE 8080/tcp
 
 WORKDIR /bin


### PR DESCRIPTION
We want to update to using that latest version of the cloud-service-broker. CloudFoundry is no longer releasing latest versions of cloud-service-broker as Docker images, so this switches to downloading their released binaries from Github and using a multi-step Docker build to copy just that binary in.

After merging this, we can take this commit as `v2.5.6gsa` and use it in our brokerpaks.