### PR TITLE
Bump Github action versions

### DIFF
--- a/.github/workflows/publish_image.yaml
+++ b/.github/workflows/publish_image.yaml
@@ -10,20 +10,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/gsa/cloud-service-broker
       - name: login to ghcr
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: publish cloud-service-broker
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true


### PR DESCRIPTION
When we merged the latest PR, there were deprecation warnings in the Github actions run. This updates all of the Github actions in the workflow to their latest major versions.

Keep on polishing.