### PR TITLE
Fix image by adding executable permssions to entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN wget --no-verbose \
 FROM alpine/k8s:1.20.7
 
 COPY --from=upstream /bin/cloud-service-broker /bin/cloud-service-broker
+RUN chmod a+x /bin/cloud-service-broker
 
 # Install git so we can use it to grab Terraform modules
 RUN apk update && apk upgrade && apk add --update git zip


### PR DESCRIPTION
The previous image that we built doesn't work because the entrypoint wasn't marked as executable.