### PR TITLE
Update docker image to CSB 2.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
-FROM alpine/k8s:1.20.7 AS upstream
+FROM alpine:3 AS upstream
 
 RUN apk update && apk upgrade && apk add --update wget
 
+ARG CSB_VERSION=2.6.1
 RUN wget --no-verbose \
-    https://github.com/cloudfoundry/cloud-service-broker/releases/download/v2.5.6/cloud-service-broker.linux \
+    https://github.com/cloudfoundry/cloud-service-broker/releases/download/v${CSB_VERSION}/cloud-service-broker.linux \
     -O /bin/cloud-service-broker
 
-FROM alpine/k8s:1.20.7
+FROM alpine:3
 
 COPY --from=upstream /bin/cloud-service-broker /bin/cloud-service-broker
 RUN chmod a+x /bin/cloud-service-broker
 
 # Install git so we can use it to grab Terraform modules
-RUN apk update && apk upgrade && apk add --update git zip
-
+RUN apk add --no-cache --update git zip jq bash
 
 # Enable re-templates of Terraform Code
 # Reference: https://github.com/GSA/data.gov/issues/3083

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GSA Cloud Service Broker
 
-This repository is used to build a Docker image that includes the Cloud Foundry [cloud service broker](https://github.com/cloudfoundry-incubator/cloud-service-broker) and utilities needed for operating data.gov brokerpaks.  For contextual information, please see each brokerpak documentation.
+This repository is used to build a Docker image that includes the Cloud Foundry [cloud service broker](https://github.com/cloudfoundry/cloud-service-broker) and utilities needed for operating data.gov brokerpaks. For contextual information, please see each brokerpak documentation.
 
 ## Contributing
 


### PR DESCRIPTION
Changes:

* Upgrades CSB to the latest released version as of 12/12/2025
* Bases docker image on base `alpine:3`
* Install `jq` and `bash` as those are used by `ttsnotify-brokerpak-sms` for testing
* Fix the link to the main csb project in the README